### PR TITLE
Adapt IndexSettingsListener for admin refactoring

### DIFF
--- a/src/EventListener/IndexSettingsListener.php
+++ b/src/EventListener/IndexSettingsListener.php
@@ -18,7 +18,7 @@ declare(strict_types=1);
 namespace Pimcore\Bundle\GoogleMarketingBundle\EventListener;
 
 use Pimcore\Bundle\GoogleMarketingBundle\Config\SiteConfigProvider;
-use Pimcore\Event\Admin\IndexActionSettingsEvent;
+use Pimcore\Bundle\AdminBundle\Event\IndexActionSettingsEvent;
 
 class IndexSettingsListener
 {


### PR DESCRIPTION
Fixes:
```
Pimcore\Bundle\GoogleMarketingBundle\EventListener\IndexSettingsListener::indexSettings(): Argument #1 ($settingsEvent) must be of type Pimcore\Event\Admin\IndexActionSettingsEvent, Pimcore\Bundle\AdminBundle\Event\IndexActionSettingsEvent given, called in /var/www/html/vendor/symfony/event-dispatcher/Debug/WrappedListener.php on line 116
```


