### PR TITLE
bugfix google-marketing-bundle destroys redirects in pimcore

### DIFF
--- a/src/EventListener/Frontend/GoogleAnalyticsCodeListener.php
+++ b/src/EventListener/Frontend/GoogleAnalyticsCodeListener.php
@@ -41,7 +41,7 @@ class GoogleAnalyticsCodeListener
 
     public function onKernelResponse(ResponseEvent $event): void
     {
-        if (!$this->isEnabled() || $event->getResponse() instanceof RedirectResponse) {
+        if (!$this->isEnabled()) {
             return;
         }
 

--- a/src/EventListener/Frontend/GoogleAnalyticsCodeListener.php
+++ b/src/EventListener/Frontend/GoogleAnalyticsCodeListener.php
@@ -41,7 +41,7 @@ class GoogleAnalyticsCodeListener
 
     public function onKernelResponse(ResponseEvent $event): void
     {
-        if (!$this->isEnabled()) {
+        if (!$this->isEnabled() || $event->getResponse() instanceof RedirectResponse) {
             return;
         }
 

--- a/src/EventListener/Frontend/GoogleTagManagerListener.php
+++ b/src/EventListener/Frontend/GoogleTagManagerListener.php
@@ -28,6 +28,7 @@ use Pimcore\Bundle\GoogleMarketingBundle\SiteId\SiteIdProvider;
 use Pimcore\Config;
 use Pimcore\Http\Request\Resolver\PimcoreContextResolver;
 use Pimcore\Tool;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\Templating\EngineInterface;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
@@ -69,7 +70,7 @@ class GoogleTagManagerListener
 
     public function onKernelResponse(ResponseEvent $event): void
     {
-        if (!$this->isEnabled()) {
+        if (!$this->isEnabled() || $event->getResponse() instanceof RedirectResponse) {
             return;
         }
 


### PR DESCRIPTION
When adding both google-marketing-bundle and ecom you will get a SessionNotFoundException when the TrackingCodeSubscriber tries to getCurrentAssortmentTenant when trying to fetch a page that has a redirect.

This is because onKernelResponse in GoogleTagManagerListener will fire the event GoogleTagManagerEvents::CODE_HEAD that the TrackingCodeSubscriber listens to and will try to get tenants that in turn requires session to be setup. Since it's a RedrectResponse no session will be found and the page will fail with a SessionNotFoundException.